### PR TITLE
(bug) Updated README to reflect proper syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ impl Assoc<Value> for Key {}
 
 #[test] fn test_pairing() {
     let mut map = TypeMap::new();
-    map.insert::<Value, Key>(Value);
-    assert_eq!(*map.find::<Value, Key>().unwrap(), Value);
+    map.insert::<Key, Value>(Value);
+    assert_eq!(*map.find::<Key, Value>().unwrap(), Value);
 }
 ```
 


### PR DESCRIPTION
Just a quick update to the README to reflect the proper <Key, Value> interface. This threw me for a loop while playing around with the new extension interface in Iron. :) 
