### PR TITLE
(fix) Add missing doc for type Value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub struct TypeMap {
 ///
 /// It is implemented for Keys, with a phantom associated type for the values.
 pub trait Key: 'static {
-    /// Phantom associated type
+    /// The value type associated with this key type.
     type Value: 'static;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,10 @@ pub struct TypeMap {
 /// This trait defines the relationship between keys and values in a TypeMap.
 ///
 /// It is implemented for Keys, with a phantom associated type for the values.
-pub trait Key: 'static { type Value: 'static; }
+pub trait Key: 'static {
+    /// Phantom associated type
+    type Value: 'static;
+}
 
 impl TypeMap {
     /// Create a new, empty TypeMap.
@@ -246,4 +249,3 @@ mod test {
         assert!(map.contains::<KeyType>());
     }
 }
-


### PR DESCRIPTION
Fix for build error:

src/lib.rs:28:31: 28:36 error: missing documentation for an associated type
src/lib.rs:28 pub trait Key: 'static { type Value: 'static; }

On rustc 1.0.0-nightly (4db0b3246 2015-02-25) (built 2015-02-26).