### PR TITLE
(release) 0.0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "typemap"
-version = "0.0.9"
+version = "0.0.10"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
 license = "MIT"
 description = "A typesafe store for many value types."


### PR DESCRIPTION
Please re-release with the newest commit, because of the missing_docs lint, release 0.0.9 doesn't build on the newest nightly.